### PR TITLE
Provide an accessor for `z_stream.next_in`.

### DIFF
--- a/Codec/Zlib/Lowlevel.hs
+++ b/Codec/Zlib/Lowlevel.hs
@@ -13,6 +13,7 @@ module Codec.Zlib.Lowlevel
     , c_set_avail_out
     , c_get_avail_out
     , c_get_avail_in
+    , c_get_next_in
     , c_call_inflate_noflush
     , c_call_deflate_noflush
     , c_call_deflate_finish
@@ -72,6 +73,9 @@ foreign import ccall unsafe "get_avail_out"
 
 foreign import ccall unsafe "get_avail_in"
     c_get_avail_in :: ZStream' -> IO CUInt
+
+foreign import ccall unsafe "get_next_in"
+    c_get_next_in :: ZStream' -> IO (Ptr CChar)
 
 foreign import ccall unsafe "call_inflate_noflush"
     c_call_inflate_noflush :: ZStream' -> IO CInt

--- a/c/helper.c
+++ b/c/helper.c
@@ -70,6 +70,11 @@ unsigned int get_avail_out (z_stream *stream)
 	return stream->avail_out;
 }
 
+char* get_next_in (z_stream *stream)
+{
+	return stream->next_in;
+}
+
 void free_z_stream_deflate (z_stream *stream)
 {
 	deflateEnd(stream);


### PR DESCRIPTION
Michael,

I have a bunch of concatenated gzip streams that I need to inflate and, in 
the course of writing a "zcat" conduit to handle this, I found the following
low-level helper function very useful.

Would you be so kind as to take a look at it and to let me know what
changes you'd like (or to merge it directly, if it looks good to you)?

Thanks very much,

Michael
